### PR TITLE
chore(docs): Punctuation and removed examples from descrption.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
             "/request_chat_id",
             get(routes::request_chat_id::request_chat_id),
         )
-        .route("/run", post(routes::run::run))
+        //.route("/run", post(routes::run::run)) // deprecated, thus removed
         .route("/cancel/:id", put(routes::cancel::cancel))
         .route("/status/:id", get(routes::status::status))
         .route("/list_log_files", get(routes::log_files::list_log_files))

--- a/src/routes/cancel.rs
+++ b/src/routes/cancel.rs
@@ -37,8 +37,8 @@ impl IntoResponse for CancelErrorReponse {
     put,
     path = "/api/cancel/{id}", 
     params(
-        ("id" = String, Path, description = "Task id. generated using the `/api/run` endpoint"),
-        ("chat_id" = String, Query, description = "Chat id. generated using the `/api/request_chat_id` endpoint")
+        ("id" = String, Path, description = "Task id. generated using the `/api/download_zip_file` endpoint."),
+        ("chat_id" = String, Query, description = "Chat id. generated using the `/api/request_chat_id` endpoint.")
     ),
     tag = "task",
     responses(

--- a/src/routes/request_chat_id.rs
+++ b/src/routes/request_chat_id.rs
@@ -21,10 +21,9 @@ impl IntoResponse for RequestChatIdReponse {
     }
 }
 
-/// Request a chat id
+/// Request a chat id.
 ///
-/// This endpoint will generate a chat id for this session. The chat id is required for every other endpoint.
-/// The chat id can be used to schedule tasks and to get the status of a task and must be provided as a query parameter.
+/// This endpoint will generate a chat id for this session. The chat id is required for every other endpoint and must be provided as a query parameter.
 #[utoipa::path(
     get,
     path = "/api/request_chat_id",

--- a/src/routes/run.rs
+++ b/src/routes/run.rs
@@ -40,6 +40,7 @@ impl IntoResponse for RunReponse {
         ("api_key" = []),
     ),
 )]
+#[deprecated(note = "replaced by `download_zip_file`")]
 pub async fn run(State(state): State<ApiState>, ChatId(chat_id): ChatId) -> RunReponse {
     let id = state.run_task(chat_id).await;
 

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -40,8 +40,8 @@ impl IntoResponse for StatusErrorReponse {
     get,
     path = "/api/status/{id}", 
     params(
-        ("id" = String, Path, description = "Task id. generated using the `/api/run` endpoint"),
-        ("chat_id" = String, Query, description = "Chat id. generated using the `/api/request_chat_id` endpoint")
+        ("id" = String, Path, description = "Task id. generated using the `/api/download_zip_file` endpoint."),
+        ("chat_id" = String, Query, description = "Chat id. generated using the `/api/request_chat_id` endpoint.")
     ),
     tag = "task",
     responses(

--- a/src/routes/upload_zip_file.rs
+++ b/src/routes/upload_zip_file.rs
@@ -57,16 +57,16 @@ pub struct DownloadZipFileQuery {
     google_drive_share_link: String,
 }
 
-/// Schedule a download of a zip file
+/// Schedule a download of a zip file from a Google Drive link.
 ///
 /// This endpoint will schedule a task for running. The task will be executed asynchronously.
 #[utoipa::path(
     post,
     path = "/api/download_zip_file", 
     params(
-        ("chat_id" = String, Query, description = "Chat id. generated using the `/api/request_chat_id` endpoint"),
-        ("project_name" = String, Query, description = "Name of the project"),
-        ("google_drive_share_link" = String, Query, description = "Google drive share link for the zip file", example = "https://drive.google.com/file/d/1FAjgIAL81UvshCn2owqlcPnvXl_k0cP2/view?usp=sharing")
+        ("chat_id" = String, Query, description = "Chat id. generated using the `/api/request_chat_id` endpoint."),
+        ("project_name" = String, Query, description = "Name of the project."),
+        ("google_drive_share_link" = String, Query, description = "Google drive share link for the zip file.")
     ),
     tag = "download",
     responses(


### PR DESCRIPTION
* added correct punctuation as this is relevant when an LLM consumes the OpenAPI spec.
* removed examples from the description as this likely causes hallucinations.
* commented out the /run endpoint as this was superseded by /download_zip_file